### PR TITLE
Add security page

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -13,6 +13,7 @@
     <li><a href="{{ site.baseurl }}/contribute/">Contribute</a></li>
     <li><a href="https://javadoc.io/doc/org.apache.stormcrawler/stormcrawler-core/3.3.0/index.html">JavaDocs</a>
     <li><a href="{{ site.baseurl }}/faq/">FAQ</a></li>
+    <li><a href="{{ site.baseurl }}/security/">Security</a></li>
     <li><a href="{{ site.baseurl }}/support/">Support</a></li>
   </ul>
 </nav>

--- a/css/main.scss
+++ b/css/main.scss
@@ -25,7 +25,7 @@ $color-light-grey: #e5e5e5;
 // Extends
 
 .row {
-	max-width:900px;
+	max-width:1000px;
 	margin:0 auto;
 	&:after {
 		@extend .clear;
@@ -120,7 +120,8 @@ p {
 .getting-started .site-nav li:nth-child(3) a,
 .contribute .site-nav li:nth-child(4) a,
 .faq .site-nav li:nth-child(6) a,
-.support .site-nav li:nth-child(7) a {
+.security .site-nav li:nth-child(7) a,
+.support .site-nav li:nth-child(8) a {
 	background:$colour-brand;
 }
 

--- a/security/index.html
+++ b/security/index.html
@@ -1,0 +1,62 @@
+---
+layout: default
+slug: security
+title: Reporting Security Problems to Apache StormCrawler
+---
+
+<div class="row row-col">
+	<h1>Security</h1>
+	<h2>Reporting New Security Problems with Apache StormCrawler</h2>
+	<p>The Apache Software Foundation takes a very active stance in eliminating security problems and denial of service attacks against its products.</p>
+	<p>We strongly encourage people to report security problems privately using the security mailing list of the <a href="https://www.apache.org/security/">ASF Security Team</a> before disclosing them in a public forum.</p>
+	<p>Please note that the security mailing list should only be used for reporting undisclosed security vulnerabilities and managing the process of fixing such vulnerabilities. We cannot accept regular bug reports or other queries at this address. All mail sent to this address that does not relate to an undisclosed security problem in our source code will be ignored.</p>
+	<p>The private security mailing address is: <a class="externalLink" href="mailto:security@stormcrawler.apache.org">security@stormcrawler.apache.org</a></p>
+
+	<h2>Threat Model and Security Considerations</h2>
+	<p>StormCrawler is designed to operate in trusted environments as part of a distributed Apache Storm cluster. This document outlines the threat model and key security assumptions to help users understand the secure use and deployment of StormCrawler.</p>
+
+	<h3>Trusted Configuration</h3>
+	<p>The configuration file used by StormCrawler is loaded during topology submission and is treated as a trusted source. It does not involve any user-supplied input at runtime.</p>
+	<p>If an attacker is able to modify this file, they would already have full access to the system, including:</p>
+	<ul>
+		<li>The ability to alter behavior of the topology</li>
+		<li>Access to credentials and other secrets</li>
+		<li>Arbitrary control over job execution</li>
+	</ul>
+	<p>Securing the configuration file and the environment in which topologies are submitted is essential. However, modification of the file implies full system compromise and is out of scope for runtime protections.</p>
+
+	<h3>Storm Cluster Security</h3>
+	<p>StormCrawler runs on an Apache Storm cluster, which is designed to allow users to:</p>
+	<ul>
+		<li>Submit topologies</li>
+		<li>Execute custom, user-defined code</li>
+	</ul>
+	<p>This model inherently trusts cluster users and assumes they are authorized.</p>
+
+	<h4>Security Recommendations:</h4>
+	<ul>
+		<li>Access to the Storm cluster must be strictly restricted to trusted users</li>
+		<li>Underlying systems should not store secrets or hold elevated privileges beyond those assigned to the authorized users</li>
+		<li>Avoid deploying StormCrawler in multi-tenant environments without strong isolation guarantees</li>
+	</ul>
+
+	<h3>Summary</h3>
+	<p>StormCrawler's security model assumes a trusted deployment environment. Users should:</p>
+	<ul>
+		<li>Secure configuration files and deployment infrastructure</li>
+		<li>Restrict Storm cluster access</li>
+		<li>Follow best practices for secret and privilege management</li>
+	</ul>
+
+	<h2>Asking Questions About Known Security Problems</h2>
+	<p>Questions about:</p>
+	<ul>
+		<li>if a vulnerability applies to your particular application</li>
+		<li>obtaining further information on a published vulnerability</li>
+		<li>availability of patches and/or new releases</li>
+	</ul>
+	<p>should be addressed to the <a href="https://lists.apache.org/list.html?dev@stormcrawler.apache.org">dev mailing list</a>.</p>
+
+	<h2>Known Security Vulnerabilities</h2>
+	<p>No known security vulnerability yet.</p>
+</div>


### PR DESCRIPTION
This PR is addressing the #36 issue.
The page contains the general security related informations, how to report security issues, etc.
The Threat model part could be improved, but it is better than nothing. :)